### PR TITLE
Switch from PyQt to PySide

### DIFF
--- a/imagediff/gui.py
+++ b/imagediff/gui.py
@@ -21,12 +21,12 @@ import sys
 from typing import Any, List, Optional
 import click
 from pathlib import Path
-from PyQt5.QtWidgets import (QApplication, QLabel, QWidget,
-                             QVBoxLayout, QListWidget, QListWidgetItem,
-                             QHBoxLayout, QGridLayout, QMainWindow,
-                             QPushButton)
-from PyQt5.QtGui import QPixmap, QResizeEvent
-from PyQt5.QtCore import Qt, QSize
+from PySide6.QtWidgets import (QApplication, QLabel, QWidget,
+                               QVBoxLayout, QListWidget, QListWidgetItem,
+                               QHBoxLayout, QGridLayout, QMainWindow,
+                               QPushButton)
+from PySide6.QtGui import QPixmap, QResizeEvent
+from PySide6.QtCore import Qt, QSize
 from .cli import ImageInfo, compare
 from PIL import Image
 from PIL.ImageQt import ImageQt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pillow==8.3.2
-PyQt5==5.15.4
+PySide6==6.3.2
 Click==8.0.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='dev@gregerstoltnilsen.net',
     license='MIT',
     packages=find_packages(include=['imagediff']),
-    install_requires=['Pillow>=8.3.2', 'PyQt5>=5.15.4', 'Click>=8.0.1'],
+    install_requires=['Pillow>=8.3.2', 'PySide6>=6.3.2', 'Click>=8.0.1'],
     python_requires='>=3',
     scripts=['bin/imagediff']
 )


### PR DESCRIPTION
PyQt doesn't support macOS/ARM when installed via PyPi, and I wasn't able to find out anything about the roadmap for this. The best I could find for macOS/ARM support were workarounds as described at e.g. https://stackoverflow.com/questions/71046800/how-to-install-pyqt5-on-m1-arm64-architecture .

PySide works out of the box.